### PR TITLE
Fixes for Tensorflow container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ common_files := $(shell find $$(pwd)/common -name Dockerfile.*)
 .PHONY: all alphafold pytorch mpi4py tensorflow
 
 all: alphafold mpi4py pytorch tensorflow rocm jax
-  echo "Built all"
+	echo "Built all"
 
 #
 # List all variation for each image here
@@ -40,15 +40,15 @@ jax: jax/build-rocm-6.2.0-python-3.12-jax-0.4.28.done
 # Generic recipe 
 #
 %.done: %.sh %.docker $(common_files)
-  set -eu ; \
-  app=$$(dirname $<) ; \
-  rp=$$(realpath $<) ; \
-  export RES=$$(realpath $@) ; \
-  cd $$(dirname $$rp) ; \
-  t=$$(basename $$rp | sed 's#^build-##g' | sed 's#.sh$$##g') ; \
-  export TAG="lumi/lumi-$$app:$$t" ; \
-  export DOCKERFILE=build-$$t.docker ; \
-  export DOCKERFILE_TMP=.tmp-build-$$t.docker ; \
-  export LOG=build-$$t.log ; \
-  $$rp
+	set -eu ; \
+	app=$$(dirname $<) ; \
+	rp=$$(realpath $<) ; \
+	export RES=$$(realpath $@) ; \
+	cd $$(dirname $$rp) ; \
+	t=$$(basename $$rp | sed 's#^build-##g' | sed 's#.sh$$##g') ; \
+	export TAG="lumi/lumi-$$app:$$t" ; \
+	export DOCKERFILE=build-$$t.docker ; \
+	export DOCKERFILE_TMP=.tmp-build-$$t.docker ; \
+	export LOG=build-$$t.log ; \
+	$$rp
   

--- a/common/Dockerfile.rocm-6.2.0
+++ b/common/Dockerfile.rocm-6.2.0
@@ -2,6 +2,11 @@
 ENV ROCM_RPM https://repo.radeon.com/amdgpu-install/6.2/sle/15.5/amdgpu-install-6.2.60200-1.noarch.rpm
 ENV ROCM_RELEASE 6.2.0
 
+# Add the devel repo to install libtbb12 required by rocrand
+RUN set -eux ; \
+  zypper -n addrepo https://download.opensuse.org/repositories/devel:/libraries:/c_c++/15.5/ myrepo5 ; \
+  echo 'gpgcheck=0' >> /etc/zypp/repos.d/myrepo5.repo
+
 RUN set -eux ; \
   zypper --no-gpg-checks -n install $ROCM_RPM
 

--- a/tensorflow/build-rocm-6.2.0-python-3.10-tensorflow-2.16.1-horovod-0.28.1.docker
+++ b/tensorflow/build-rocm-6.2.0-python-3.10-tensorflow-2.16.1-horovod-0.28.1.docker
@@ -11,6 +11,10 @@ ARG TENSORFLOW_VERSION
 RUN $WITH_CONDA; set -eux ; \
   pip install tensorflow-rocm==$TENSORFLOW_VERSION -f https://repo.radeon.com/rocm/manylinux/rocm-rel-6.2/
 
+ARG TF_KERAS_VERSION
+RUN $WITH_CONDA; set -eux ; \
+  pip install --no-deps tf-keras==$TF_KERAS_VERSION
+
 #
 # Install horovod
 #

--- a/tensorflow/build-rocm-6.2.0-python-3.10-tensorflow-2.16.1-horovod-0.28.1.sh
+++ b/tensorflow/build-rocm-6.2.0-python-3.10-tensorflow-2.16.1-horovod-0.28.1.sh
@@ -5,6 +5,7 @@ PYTHON_VERSION='3.10'
 TENSORFLOW_VERSION='2.16.1'
 HOROVOD_VERSION='0.28.1'
 OPENNMT_VERSION='2.32.0'
+TF_KERAS_VERSION='2.16.0'
 
 cat \
   ../common/Dockerfile.header \
@@ -22,6 +23,7 @@ $DOCKERBUILD \
   --build-arg TENSORFLOW_VERSION=$TENSORFLOW_VERSION \
   --build-arg HOROVOD_VERSION=$HOROVOD_VERSION \
   --build-arg OPENNMT_VERSION='' \
+  --build-arg TF_KERAS_VERSION=$TF_KERAS_VERSION \
   --progress=plain -t $TAG . 2>&1 | tee $LOG
 
 $DOCKERBUILD \
@@ -31,6 +33,7 @@ $DOCKERBUILD \
   --build-arg TENSORFLOW_VERSION=$TENSORFLOW_VERSION \
   --build-arg HOROVOD_VERSION=$HOROVOD_VERSION \
   --build-arg OPENNMT_VERSION=$OPENNMT_VERSION \
+  --build-arg TF_KERAS_VERSION=$TF_KERAS_VERSION \
   --progress=plain -t $TAG-opennmt-$OPENNMT_VERSION . 2>&1 | tee -a $LOG
   
 echo "$TAG" > $RES


### PR DESCRIPTION
Fixes for the TensorFlow container:
  - Make sure libtbb12, dependency of rocrand is installed to avoid failure of TensorFlow GPU backend initialization
  - Install keras-tf in order to provide Keras 2 so that the user can choose between Keras 3 or 2 via an environment variable

Also include a fix to the Makefile, replacing spaces with tabulations.