### PR TITLE
Pytorch v2.4 fix

### DIFF
--- a/pytorch/build-rocm-6.1.3-python-3.12-pytorch-v2.4.0.docker
+++ b/pytorch/build-rocm-6.1.3-python-3.12-pytorch-v2.4.0.docker
@@ -16,13 +16,18 @@ RUN set -eux ; \
 # Install pytorch
 # 
 
+# PyTorch comes with RCCL from ROCm 6.0.0 which cause a segmentation fault 
+# in the tests. It's supspected it's related to https://github.com/ROCm/rccl/pull/1153
+# Copying the RCCL library from /opt/rocm, solve the issue.
+
 ENV PYTORCH_ROCM_ARCH gfx90a 
 ARG PYTORCH_VERSION
 ARG PYTORCH_DEBUG
 ARG PYTORCH_RELWITHDEBINFO
 
 RUN $WITH_CONDA; set -eux ; \
-  pip3 install --pre torch==${PYTORCH_VERSION} --index-url https://download.pytorch.org/whl/
+  pip3 install --pre torch==${PYTORCH_VERSION} --index-url https://download.pytorch.org/whl/ ; \
+  cp /opt/rocm/lib/librccl.so $(dirname $(python -c 'import torch; print(torch.__file__)'))/lib
 
 #
 # Pytorch dependencies

--- a/pytorch/build-rocm-6.1.3-python-3.12-pytorch-v2.4.0.docker
+++ b/pytorch/build-rocm-6.1.3-python-3.12-pytorch-v2.4.0.docker
@@ -42,6 +42,14 @@ ARG TORCHVISION_VERSION
 RUN $WITH_CONDA; set -eux ; \
   pip3 install --pre torchvision==$TORCHVISION_VERSION --index-url https://download.pytorch.org/whl/
 
+#
+# AMD-SMI
+#
+RUN $WITH_CONDA; set -eux ; \
+  cd $ROCM_PATH/share/amd_smi ; \
+  python3 -m pip wheel . --wheel-dir=/opt/wheels ; \
+  pip install /opt/wheels/amdsmi-*.whl
+
 ARG TORCHDATA_VERSION
 RUN $WITH_CONDA; set -eux ; \
   pip3 install --pre torchdata==$TORCHDATA_VERSION --index-url https://download.pytorch.org/whl/


### PR DESCRIPTION
Fix two issues in the PyTorch v2.4 container:
 
- **AMD-SMI not found:** install amd-smi in the Conda environment
- **RCCL segfault:** Copy the /opt/rocm RCCL library to the PyTorch installation